### PR TITLE
Correct path to Thunderbird ThirdPartyPaths.txt

### DIFF
--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -203,7 +203,7 @@ const getThirdPartyPaths = (function() {
   let paths = null;
   return async function() {
     if (!paths) {
-      const response = await getSource("tools/rewriting/ThirdPartyPaths.txt");
+      const response = await getSource("tools/lint/ThirdPartyPaths.txt");
       paths = response.split("\n").filter(path => path !== "");
     }
 


### PR DESCRIPTION
This fixes https://coverage.thunderbird.net/#view=zero&revision=latest&path=&third_party=off (to at least not error out the same way it currently does)