### PR TITLE
Use ${{ github.sha }} to append commit has to image name. The task de…

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -52,7 +52,7 @@ jobs:
       id: build-backend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        IMAGE_TAG: backend-latest
+        IMAGE_TAG: backend-${{ github.sha }}
       run: |
         # Build a docker container and
         # push it to ECR so that it can
@@ -65,7 +65,7 @@ jobs:
       id: build-frontend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        IMAGE_TAG: frontend-latest
+        IMAGE_TAG: frontend-${{ github.sha }}
       run: |
         # Build a docker container and
         # push it to ECR so that it can
@@ -79,7 +79,7 @@ jobs:
       id: build-bot
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        IMAGE_TAG: bot-latest
+        IMAGE_TAG: bot-${{ github.sha }}
       run: |
         # Build a docker container and
         # push it to ECR so that it can


### PR DESCRIPTION
Issue #12 
We need to enable immutable image tags on ECR, currently we are pushing to the same tag names and overwriting them.

Appends full git hash to container tag name, eg. backend-${{ github.sha }} during image build stages of the publishing workflow.
The task definition stage should pick up the correct name from the build stage output.
