### PR TITLE
ci(aws): migrate deploy workflow to OIDC role assumption

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -2,6 +2,7 @@
 # task definition revision, on push to the `deploy` branch.
 #
 # Auth: OIDC role assumption — no long-lived AWS credentials in repo secrets.
+# Role ARN comes from the `production` environment secret AWS_ROLE_ARN.
 # Role: thunderbird-legacy-github-oidc-prod-code-coverage-prod (in account
 # 768512802988, provisioned by thunderbird/platform-infrastructure).
 # Trust is scoped to repo:thunderbird/code-coverage:environment:production.
@@ -46,7 +47,9 @@ jobs:
     - name: Configure AWS credentials (OIDC)
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-code-coverage-prod
+        # AWS_ROLE_ARN is the production environment secret; the role itself is
+        # provisioned in thunderbird/platform-infrastructure (see file header).
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,5 +1,10 @@
-# This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, when there is a push to the "staging" branch.
+# Builds and pushes container images to Amazon ECR, then deploys a new ECS
+# task definition revision, on push to the `deploy` branch.
+#
+# Auth: OIDC role assumption — no long-lived AWS credentials in repo secrets.
+# Role: thunderbird-legacy-github-oidc-prod-code-coverage-prod (in account
+# 768512802988, provisioned by thunderbird/platform-infrastructure).
+# Trust is scoped to repo:thunderbird/code-coverage:environment:production.
 
 name: Deploy to Production Environment
 
@@ -24,6 +29,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write     # required for OIDC role assumption
 
 jobs:
   deploy:
@@ -35,18 +41,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-code-coverage-prod
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Build, tag, and push backend to Amazon ECR
       id: build-backend


### PR DESCRIPTION
## Summary

Switches `.github/workflows/aws.yml` from long-lived AWS access keys to **GitHub OIDC role assumption**. Removes the dependency on `secrets.AWS_ACCESS_KEY_ID` + `secrets.AWS_SECRET_ACCESS_KEY` in the `production` environment.

### What changes

- Adds `id-token: write` to the workflow `permissions` block (required for OIDC).
- Replaces `aws-access-key-id` / `aws-secret-access-key` with `role-to-assume: ${{ secrets.AWS_ROLE_ARN }}` — fetched from the `production` GitHub Environment, matching the pattern in thunderbird/appointment, thunderbird-accounts, and tbpro-add-on.
- Bumps action versions:
  - `actions/checkout` v3 → v4
  - `aws-actions/configure-aws-credentials` v1 → v4 (OIDC requires v2+, picking the same v4 used by other thunderbird OIDC workflows)
  - `aws-actions/amazon-ecr-login` v1 → v2
- Refreshes the file header comment (it said "staging branch" but the workflow has triggered on push to `deploy` for a while).

The 3 docker build/push steps and the 2 task-definition-render + deploy steps are **unchanged**.

### Sequencing

The role this workflow assumes is provisioned in [`thunderbird/platform-infrastructure` PR #335](https://github.com/thunderbird/platform-infrastructure/pull/335). We test the IAM permissions against a real deploy BEFORE that PR merges — so we can adjust the role from the `#335` branch and re-`pulumi up` if anything is wrong, rather than chasing fixes through a series of merged PRs.

**Test + merge order:**

1. From the `feat/327-code-coverage-oidc` branch of `thunderbird/platform-infrastructure`, run `pulumi up` against the `thunderbird-legacy-github-oidc/prod` stack. Creates the role in account `768512802988`.
2. In this repo's settings → Environments → `production`, add a **secret** named `AWS_ROLE_ARN` with value:
   `arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-code-coverage-prod`
3. Merge this PR (`code-coverage#16`) into `thunderbird` (default branch).
4. Promote `thunderbird` → `deploy` to trigger the first OIDC-authenticated deploy.
5. **If the deploy fails on IAM**: tweak `pulumi/environments/thunderbird-legacy-github-oidc/__main__.py` on the `feat/327-code-coverage-oidc` branch, `pulumi up` to apply the fix, push the branch (PR #335 updates), re-promote to `deploy` to retry. Repeat until the workflow succeeds.
6. **Once the deploy is green**: merge `platform-infrastructure#335` to lock in the validated role definition.
7. Follow up in `platform-infrastructure#327` to delete the legacy `coverage-ci` IAM user + access keys + customer policy + repo secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).

### Role-trust details (for review confidence)

The role's IAM trust policy:

```json
{
  "Effect": "Allow",
  "Principal": {"Federated": "arn:aws:iam::768512802988:oidc-provider/token.actions.githubusercontent.com"},
  "Action": "sts:AssumeRoleWithWebIdentity",
  "Condition": {
    "StringEquals": {
      "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
      "token.actions.githubusercontent.com:sub": "repo:thunderbird/code-coverage:environment:production"
    }
  }
}
```

`StringEquals` (not `StringLike`) — the sub claim must match `repo:thunderbird/code-coverage:environment:production` **exactly**. Pull-requests + non-`deploy`-branch pushes cannot assume this role.

The role's permissions are minimum-scope: ECR push on `repository/coverage`, ECS RegisterTaskDefinition + UpdateService on `service/coverage/coverage-service`, and `iam:PassRole` on `role/coverage-ci` (the ECS task execution role) gated by `iam:PassedToService = ecs-tasks.amazonaws.com`. Full details in [platform-infrastructure#335](https://github.com/thunderbird/platform-infrastructure/pull/335).

### Test plan

- [ ] `pulumi up` run from the `feat/327-code-coverage-oidc` branch of platform-infrastructure (creates role in 768512802988)
- [ ] Set `AWS_ROLE_ARN` secret in this repo's `production` environment
- [ ] Merge this PR into `thunderbird`
- [ ] Promote `thunderbird` → `deploy`; first OIDC workflow run reaches "Deploy Amazon ECS task definition" + ECS service stabilizes
- [ ] Verify new task def revision is registered + running task uses the freshly-pushed images
- [ ] If IAM needs adjustment: edit `__main__.py` on the `feat/327-code-coverage-oidc` branch, `pulumi up`, re-test
- [ ] Once green: merge platform-infrastructure#335
- [ ] Open follow-up in platform-infrastructure#327 to delete `coverage-ci` IAM user + repo secrets

Refs: thunderbird/platform-infrastructure#327
